### PR TITLE
Bump avhengigheter (Kotlin 2 og Ktor 3)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,14 +14,13 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
-          cache: gradle
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Publish artifact
         run: ./gradlew publish

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,14 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
-          cache: gradle
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Build and test
         run: ./gradlew build test

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 
 kotlin {
     compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_17)
+        jvmTarget = JvmTarget.JVM_21
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,12 @@
 kotlin.code.style=official
 
 # Plugin versions
-kotlinVersion=1.9.10
+kotlinVersion=2.0.21
 kotlinterVersion=3.16.0
 
 # Dependency versions
-kotestVersion=5.7.2
-ktorVersion=2.3.4
-logbackVersion=1.4.11
-mockkVersion=1.13.8
-utilsVersion=0.7.0
+kotestVersion=5.9.1
+ktorVersion=3.1.2
+logbackVersion=1.5.18
+mockkVersion=1.14.0
+utilsVersion=0.9.0

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dokarkiv/DokArkivClient.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dokarkiv/DokArkivClient.kt
@@ -24,7 +24,7 @@ import java.time.LocalDate
 
 class DokArkivClient(
     private val url: String,
-    private val maxRetries: Int = 0,
+    maxRetries: Int = 0,
     private val getAccessToken: () -> String,
 ) {
     private val logger = logger()

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dokarkiv/HttpUtils.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dokarkiv/HttpUtils.kt
@@ -41,6 +41,5 @@ private fun Throwable.isRetryableException() =
         is SocketTimeoutException -> true
         is ConnectTimeoutException -> true
         is HttpRequestTimeoutException -> true
-        is java.net.SocketTimeoutException -> true
         else -> false
     }


### PR DESCRIPTION
Går også over til Java 21. Dette, og bump til Kotlin 2 og Ktor 3, er de mest substansielle endringene.