### PR TITLE
Legg til retry og timeout

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,4 +9,4 @@ kotestVersion=5.9.1
 ktorVersion=3.1.2
 logbackVersion=1.5.18
 mockkVersion=1.14.0
-utilsVersion=0.9.0
+utilsVersion=0.10.1

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dokarkiv/DokArkivClient.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dokarkiv/DokArkivClient.kt
@@ -25,12 +25,11 @@ import java.time.LocalDate
 
 class DokArkivClient(
     private val url: String,
-    maxRetries: Int = 0,
     private val getAccessToken: () -> String,
 ) {
     private val logger = logger()
 
-    private val httpClient = createHttpClient(maxRetries)
+    private val httpClient = createHttpClient()
 
     /**
      * Oppretter en journalpost i Joark/dokarkiv, med eller uten dokumenter, og forsøker å ferdigstille.

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dokarkiv/HttpUtils.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dokarkiv/HttpUtils.kt
@@ -3,43 +3,42 @@ package no.nav.helsearbeidsgiver.dokarkiv
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.engine.apache5.Apache5
-import io.ktor.client.network.sockets.ConnectTimeoutException
-import io.ktor.client.network.sockets.SocketTimeoutException
 import io.ktor.client.plugins.HttpRequestRetry
-import io.ktor.client.plugins.HttpRequestTimeoutException
+import io.ktor.client.plugins.HttpRequestRetryConfig
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.header
 import io.ktor.serialization.kotlinx.json.json
 import no.nav.helsearbeidsgiver.utils.json.jsonConfig
 
-internal fun createHttpClient(maxRetries: Int): HttpClient =
-    HttpClient(Apache5) { configure(maxRetries) }
+internal fun createHttpClient(): HttpClient =
+    HttpClient(Apache5) { configure() }
 
-internal fun HttpClientConfig<*>.configure(retries: Int) {
+internal fun HttpClientConfig<*>.configure() {
     expectSuccess = true
 
     install(ContentNegotiation) {
         json(jsonConfig)
     }
-    install(HttpRequestRetry) {
-        maxRetries = retries
-        retryOnServerErrors(maxRetries)
-        retryOnExceptionIf { _, cause ->
-            cause.isRetryableException()
-        }
-        exponentialDelay()
+
+    install(HttpRequestRetry) { configureRetry() }
+
+    install(HttpTimeout) {
+        connectTimeoutMillis = 500
+        requestTimeoutMillis = 500
+        socketTimeoutMillis = 500
     }
+}
+
+internal fun HttpRequestRetryConfig.configureRetry() {
+    retryOnException(
+        maxRetries = 3,
+        retryOnTimeout = true,
+    )
+    exponentialDelay()
 }
 
 internal fun HttpRequestBuilder.navCallId(callId: String) {
     header("Nav-Call-Id", callId)
 }
-
-private fun Throwable.isRetryableException() =
-    when (this) {
-        is SocketTimeoutException -> true
-        is ConnectTimeoutException -> true
-        is HttpRequestTimeoutException -> true
-        else -> false
-    }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/dokarkiv/MockUtils.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/dokarkiv/MockUtils.kt
@@ -1,32 +1,59 @@
 package no.nav.helsearbeidsgiver.dokarkiv
 
+import io.kotest.core.test.testCoroutineScheduler
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.HttpRequestRetry
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.mockk.every
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import no.nav.helsearbeidsgiver.dokarkiv.domene.Avsender
 import no.nav.helsearbeidsgiver.dokarkiv.domene.DokumentInfoId
 import no.nav.helsearbeidsgiver.dokarkiv.domene.GjelderPerson
 import no.nav.helsearbeidsgiver.dokarkiv.domene.OpprettOgFerdigstillResponse
 import no.nav.helsearbeidsgiver.utils.test.mock.mockStatic
 
-fun mockDokArkivClient(content: String, status: HttpStatusCode): DokArkivClient {
-    val mockEngine = MockEngine {
-        respond(
-            content = content,
-            status = status,
-            headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+@OptIn(ExperimentalStdlibApi::class, ExperimentalCoroutinesApi::class)
+fun mockDokArkivClient(vararg responses: Pair<HttpStatusCode, String>): DokArkivClient {
+    val mockEngine = MockEngine.create {
+        reuseHandlers = false
+        requestHandlers.addAll(
+            responses.map { (status, content) ->
+                {
+                    if (content == "timeout") {
+                        // Skrur den virtuelle klokka fremover, nok til at timeout forårsakes
+                        dispatcher.shouldNotBeNull().testCoroutineScheduler.advanceTimeBy(1)
+                    }
+                    respond(
+                        content = content,
+                        status = status,
+                        headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+                    )
+                }
+            },
         )
     }
 
-    val mockHttpClient = HttpClient(mockEngine) { configure(retries = 0) }
+    val mockHttpClient = HttpClient(mockEngine) {
+        configure()
+
+        // Overstyr delay for å unngå at testene bruker lang tid
+        install(HttpRequestRetry) {
+            configureRetry()
+            constantDelay(
+                millis = 1,
+                randomizationMs = 1,
+            )
+        }
+    }
 
     return mockStatic(::createHttpClient) {
-        every { createHttpClient(any()) } returns mockHttpClient
+        every { createHttpClient() } returns mockHttpClient
         DokArkivClient("mock url") { "mock access token" }
     }
 }


### PR DESCRIPTION
Timeout er basert på data på Grafana som tilsier at et kall vanligvis tar 200 ms.

https://grafana.nav.cloud.nais.io/d/rZtfrreVz/simba-inntektsmelding?orgId=1&from=now-7d&to=now&timezone=browser&var-env=000000021
